### PR TITLE
Migrated to Swift 3.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: objective-c
 osx_image: xcode8
 xcode_project: "Test/Thread.xcodeproj"
-xcode_scheme: ThreadOSX
+xcode_scheme: ThreadiOS
 xcode_sdk: iphonesimulator10.0
 before_install:
   - gem install xcpretty

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-osx_image: xcode7.1
+osx_image: xcode8.1
 language: objective-c
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,10 @@
 language: objective-c
 osx_image: xcode8
-
-env:
-  global:
-  - PROJECT="Test/Thread.xcodeproj"
-
+xcode_project: "Test/Thread.xcodeproj"
+xcode_scheme: ThreadOSX
+xcode_sdk: iphonesimulator10.0
 before_install:
   - gem install xcpretty
-
 script:
   - set -o pipefail
-  - xcodebuild -version
-  - xcodebuild -showsdks
-  
-  - xcodebuild -project "$PROJECT" -scheme 'ThreadiOS' -destination 'name=iPhone 6,OS=10.0' ONLY_ACTIVE_ARCH=NO CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO build | xcpretty
-  - xcodebuild -project "$PROJECT" -scheme 'ThreadtvOS' -sdk appletvsimulator10.0 -destination 'name=Apple TV 1080p' ONLY_ACTIVE_ARCH=NO CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO build | xcpretty
-  - xcodebuild -project "$PROJECT" -scheme 'ThreadOSX' ONLY_ACTIVE_ARCH=NO CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO build | xcpretty
-  
-  - xcodebuild -project "$PROJECT" -scheme 'ThreadiOS' -sdk iphonesimulator -destination 'name=iPhone 6,OS=10.0' ONLY_ACTIVE_ARCH=NO CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO test | xcpretty
-  - xcodebuild -project "$PROJECT" -scheme 'ThreadtvOS' -sdk appletvsimulator10.0 -destination 'name=Apple TV 1080p' ONLY_ACTIVE_ARCH=NO CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO test | xcpretty
-  - xcodebuild -project "$PROJECT" -scheme 'ThreadOSX' ONLY_ACTIVE_ARCH=NO CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO test | xcpretty
+  - xcodebuild -project $TRAVIS_XCODE_PROJECT -scheme $TRAVIS_XCODE_SCHEME -sdk $TRAVIS_XCODE_SDK -destination 'name=iPhone 6' test | xcpretty -c

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: objective-c
 osx_image: xcode8
-xcode_project: "Test/Thread.xcodeproj"
-xcode_scheme: ThreadiOS
-xcode_sdk: iphonesimulator10.0
+
 before_install:
   - gem install xcpretty
+  
 script:
-  - set -o pipefail
-  - xcodebuild -project $TRAVIS_XCODE_PROJECT -scheme $TRAVIS_XCODE_SCHEME -sdk $TRAVIS_XCODE_SDK -destination 'name=iPhone 6' test | xcpretty -c
+  - set -o pipefail && xcodebuild clean build test -project Test/Thread.xcodeproj -scheme "ThreadOSX" GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES GCC_GENERATE_TEST_COVERAGE_FILES=YES ONLY_ACTIVE_ARCH=NO | xcpretty
+  - set -o pipefail && xcodebuild test -project Test/Thread.xcodeproj -scheme "ThreadOSX" | xcpretty

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,4 @@ osx_image: xcode8.1
 language: objective-c
 
 script:
-- xctool build test -project Test/Thread.xcodeproj -scheme "ThreadOSX"
+- xctool build test -project Test/Thread.xcodeproj -scheme "ThreadiOS"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,22 @@
-osx_image: xcode8.1
 language: objective-c
+osx_image: xcode8
+
+env:
+  global:
+  - PROJECT="Test/Thread.xcodeproj"
+
+before_install:
+  - gem install xcpretty
 
 script:
-- xctool build test -project Test/Thread.xcodeproj -scheme "ThreadOSX"
+  - set -o pipefail
+  - xcodebuild -version
+  - xcodebuild -showsdks
+  
+  - xcodebuild -project "$PROJECT" -scheme 'ThreadiOS' -destination 'name=iPhone 6,OS=10.0' ONLY_ACTIVE_ARCH=NO CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO build | xcpretty
+  - xcodebuild -project "$PROJECT" -scheme 'ThreadtvOS' -sdk appletvsimulator10.0 -destination 'name=Apple TV 1080p' ONLY_ACTIVE_ARCH=NO CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO build | xcpretty
+  - xcodebuild -project "$PROJECT" -scheme 'ThreadOSX' ONLY_ACTIVE_ARCH=NO CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO build | xcpretty
+  
+  - xcodebuild -project "$PROJECT" -scheme 'ThreadiOS' -sdk iphonesimulator -destination 'name=iPhone 6,OS=10.0' ONLY_ACTIVE_ARCH=NO CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO test | xcpretty
+  - xcodebuild -project "$PROJECT" -scheme 'ThreadtvOS' -sdk appletvsimulator10.0 -destination 'name=Apple TV 1080p' ONLY_ACTIVE_ARCH=NO CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO test | xcpretty
+  - xcodebuild -project "$PROJECT" -scheme 'ThreadOSX' ONLY_ACTIVE_ARCH=NO CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO test | xcpretty

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,4 @@ osx_image: xcode8.1
 language: objective-c
 
 script:
-- xctool build test -project Test/Thread.xcodeproj -scheme "ThreadiOS"
+- xctool build test -project Test/Thread.xcodeproj -scheme "ThreadOSX"

--- a/Source/Thread.swift
+++ b/Source/Thread.swift
@@ -12,8 +12,11 @@
 
 import Foundation
 
+/// Used to resolve naming conflicts and unit tests
+typealias SwiftyThread = Thread
+
 /// FIFO. First-In-First-Out guaranteed on exactly same thread.
-class Thread: NSThread {
+class Thread: Foundation.Thread {
     
     typealias Block = () -> ()
 
@@ -56,14 +59,14 @@ class Thread: NSThread {
 
             // 2. Test a boolean predicate. (This predicate is a boolean flag or other variable in your code that indicates whether it is safe to perform the task protected by the condition.)
             // If no blocks (or paused) and not cancelled
-            while (queue.count == 0 || paused) && !cancelled  {
+            while (queue.count == 0 || paused) && !isCancelled  {
                 // 3. If the boolean predicate is false, call the condition object’s wait or waitUntilDate: method to block the thread. Upon returning from these methods, go to step 2 to retest your boolean predicate. (Continue waiting and retesting the predicate until it is true.)
                 condition.wait()
             }
             // 4. If the boolean predicate is true, perform the task.
 
             // If your thread supports cancellation, it should check this property periodically and exit if it ever returns true.
-            if (cancelled) {
+            if (isCancelled) {
                 condition.unlock()
                 return
             }
@@ -84,7 +87,7 @@ class Thread: NSThread {
      - parameters:
         - block: The code to run.
      */
-    final func enqueue(block: Block) {
+    final func enqueue(_ block: @escaping Block) {
         // Lock to ensure first-in gets added to array first
         condition.lock()
         // Add to queue

--- a/Source/Thread.swift
+++ b/Source/Thread.swift
@@ -12,9 +12,6 @@
 
 import Foundation
 
-/// Used to resolve naming conflicts and unit tests
-typealias SwiftyThread = Thread
-
 /// FIFO. First-In-First-Out guaranteed on exactly same thread.
 class Thread: Foundation.Thread {
     

--- a/Test/Thread.xcodeproj/project.pbxproj
+++ b/Test/Thread.xcodeproj/project.pbxproj
@@ -329,28 +329,36 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0720;
-				LastUpgradeCheck = 0720;
+				LastUpgradeCheck = 0810;
 				ORGANIZATIONNAME = developmunk;
 				TargetAttributes = {
 					4E4694331C09F3370063D651 = {
 						CreatedOnToolsVersion = 7.2;
+						LastSwiftMigration = 0810;
 					};
 					4E4694461C09F3370063D651 = {
 						CreatedOnToolsVersion = 7.2;
+						LastSwiftMigration = 0810;
 						TestTargetID = 4E4694331C09F3370063D651;
 					};
 					4E4694591C09F38E0063D651 = {
 						CreatedOnToolsVersion = 7.2;
+						LastSwiftMigration = 0810;
+						ProvisioningStyle = Automatic;
 					};
 					4E4694691C09F38E0063D651 = {
 						CreatedOnToolsVersion = 7.2;
+						LastSwiftMigration = 0810;
 						TestTargetID = 4E4694591C09F38E0063D651;
 					};
 					4E46947C1C0A585D0063D651 = {
 						CreatedOnToolsVersion = 7.2;
+						LastSwiftMigration = 0810;
+						ProvisioningStyle = Automatic;
 					};
 					4E46948A1C0A585D0063D651 = {
 						CreatedOnToolsVersion = 7.2;
+						LastSwiftMigration = 0810;
 						TestTargetID = 4E46947C1C0A585D0063D651;
 					};
 				};
@@ -553,8 +561,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -578,8 +588,10 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.2;
 				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0.1;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -597,8 +609,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -617,6 +631,8 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 9.2;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0.1;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 			};
@@ -809,6 +825,7 @@
 				4E4694501C09F3370063D651 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		4E4694511C09F3370063D651 /* Build configuration list for PBXNativeTarget "ThreadiOSTests" */ = {
 			isa = XCConfigurationList;
@@ -817,6 +834,7 @@
 				4E4694531C09F3370063D651 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		4E4694711C09F38E0063D651 /* Build configuration list for PBXNativeTarget "ThreadtvOS" */ = {
 			isa = XCConfigurationList;
@@ -825,6 +843,7 @@
 				4E4694731C09F38E0063D651 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		4E4694741C09F38E0063D651 /* Build configuration list for PBXNativeTarget "ThreadtvOSTests" */ = {
 			isa = XCConfigurationList;
@@ -833,6 +852,7 @@
 				4E4694761C09F38E0063D651 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		4E4694921C0A585D0063D651 /* Build configuration list for PBXNativeTarget "ThreadOSX" */ = {
 			isa = XCConfigurationList;
@@ -841,6 +861,7 @@
 				4E4694941C0A585D0063D651 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		4E4694951C0A585D0063D651 /* Build configuration list for PBXNativeTarget "ThreadOSXTests" */ = {
 			isa = XCConfigurationList;
@@ -849,6 +870,7 @@
 				4E4694971C0A585D0063D651 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/Test/Thread.xcodeproj/project.pbxproj
+++ b/Test/Thread.xcodeproj/project.pbxproj
@@ -642,6 +642,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = ThreadiOS/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = dk.developmunk.ThreadiOS;
@@ -653,6 +654,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = ThreadiOS/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = dk.developmunk.ThreadiOS;
@@ -746,8 +748,9 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_IDENTITY = "Mac Developer";
 				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = ThreadOSX/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
@@ -762,8 +765,9 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_IDENTITY = "Mac Developer";
 				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = ThreadOSX/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;

--- a/Test/Thread.xcodeproj/xcshareddata/xcschemes/ThreadOSX.xcscheme
+++ b/Test/Thread.xcodeproj/xcshareddata/xcschemes/ThreadOSX.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0720"
+   LastUpgradeVersion = "0810"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Test/Thread.xcodeproj/xcshareddata/xcschemes/ThreadiOS.xcscheme
+++ b/Test/Thread.xcodeproj/xcshareddata/xcschemes/ThreadiOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0720"
+   LastUpgradeVersion = "0810"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -36,6 +36,26 @@
                BlueprintIdentifier = "4E4694461C09F3370063D651"
                BuildableName = "ThreadiOSTests.xctest"
                BlueprintName = "ThreadiOSTests"
+               ReferencedContainer = "container:Thread.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4E46948A1C0A585D0063D651"
+               BuildableName = "ThreadOSXTests.xctest"
+               BlueprintName = "ThreadOSXTests"
+               ReferencedContainer = "container:Thread.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4E4694691C09F38E0063D651"
+               BuildableName = "ThreadtvOSTests.xctest"
+               BlueprintName = "ThreadtvOSTests"
                ReferencedContainer = "container:Thread.xcodeproj">
             </BuildableReference>
          </TestableReference>

--- a/Test/Thread.xcodeproj/xcshareddata/xcschemes/ThreadtvOS.xcscheme
+++ b/Test/Thread.xcodeproj/xcshareddata/xcschemes/ThreadtvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0720"
+   LastUpgradeVersion = "0810"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Test/ThreadOSX/AppDelegate.swift
+++ b/Test/ThreadOSX/AppDelegate.swift
@@ -14,11 +14,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     @IBOutlet weak var window: NSWindow!
 
 
-    func applicationDidFinishLaunching(aNotification: NSNotification) {
+    func applicationDidFinishLaunching(_ aNotification: Notification) {
         // Insert code here to initialize your application
     }
 
-    func applicationWillTerminate(aNotification: NSNotification) {
+    func applicationWillTerminate(_ aNotification: Notification) {
         // Insert code here to tear down your application
     }
 

--- a/Test/ThreadTests.swift
+++ b/Test/ThreadTests.swift
@@ -28,20 +28,20 @@ class ThreadTests: XCTestCase {
     }
     
     func testEnqueueSingle() {
-        let expectation = expectationWithDescription("First")
+        let expectation = self.expectation(description: "First")
 
-        let thread = Thread()
+        let thread = SwiftyThread()
         thread.enqueue {
             expectation.fulfill()
         }
-        waitForExpectationsWithTimeout(1, handler: nil)
+        waitForExpectations(timeout: 1, handler: nil)
     }
 
     func testEnqueueMultiple() {
-        let expectation1 = expectationWithDescription("First")
-        let expectation2 = expectationWithDescription("Second")
+        let expectation1 = expectation(description: "First")
+        let expectation2 = expectation(description: "Second")
 
-        let thread = Thread()
+        let thread = SwiftyThread()
         var visitedFirst = false
         thread.enqueue {
             expectation1.fulfill()
@@ -51,14 +51,14 @@ class ThreadTests: XCTestCase {
             expectation2.fulfill()
             XCTAssert(visitedFirst, "Didn't run first before this secondary block")
         }
-        waitForExpectationsWithTimeout(1, handler: nil)
+        waitForExpectations(timeout: 1, handler: nil)
     }
 
     func testCancel() {
-        let expectation1 = expectationWithDescription("First")
-        let expectationWait = expectationWithDescription("Wait")
+        let expectation1 = expectation(description: "First")
+        let expectationWait = expectation(description: "Wait")
 
-        let thread = Thread()
+        let thread = SwiftyThread()
         thread.enqueue {
             thread.cancel()
             expectation1.fulfill()
@@ -72,22 +72,22 @@ class ThreadTests: XCTestCase {
         }
 
         // Wait
-        waitForExpectationsWithTimeout(1, handler: nil)
+        waitForExpectations(timeout: 1, handler: nil)
     }
 
     func testEmptyQueue() {
-        let expectation1 = expectationWithDescription("First")
-        let expectationWait = expectationWithDescription("Wait")
+        let expectation1 = expectation(description: "First")
+        let expectationWait = expectation(description: "Wait")
 
-        let thread = Thread()
+        let thread = SwiftyThread()
         thread.enqueue {
             expectation1.fulfill()
-            NSThread.sleepForTimeInterval(0.1)
+            Thread.sleep(forTimeInterval: 0.1)
         }
         thread.enqueue {
             XCTFail("This block is enqueued after first block, so shouldn't be run")
         }
-        dispatch_async(dispatch_get_main_queue()) {
+        DispatchQueue.main.async {
             XCTAssertEqual(thread.queue.count, 1)
             thread.emptyQueue()
             XCTAssertEqual(thread.queue.count, 0)
@@ -98,15 +98,15 @@ class ThreadTests: XCTestCase {
         }
 
         // Wait
-        waitForExpectationsWithTimeout(1, handler: nil)
+        waitForExpectations(timeout: 1, handler: nil)
     }
 
     func testPause() {
-        let expectation1 = expectationWithDescription("First")
-        let expectation2 = expectationWithDescription("Second")
-        let expectationWait = expectationWithDescription("Wait")
+        let expectation1 = expectation(description: "First")
+        let expectation2 = expectation(description: "Second")
+        let expectationWait = expectation(description: "Wait")
 
-        let thread = Thread()
+        let thread = SwiftyThread()
         var paused: Bool = false
         var resumed: Bool = false
         thread.enqueue {
@@ -129,7 +129,7 @@ class ThreadTests: XCTestCase {
         }
 
         // Wait
-        waitForExpectationsWithTimeout(1, handler: nil)
+        waitForExpectations(timeout: 1, handler: nil)
     }
 
     func testInitialQueue() {
@@ -141,13 +141,13 @@ class ThreadTests: XCTestCase {
 
 extension ThreadTests {
 
-    private func asyncAfter(seconds: Double, queue: dispatch_queue_t = dispatch_get_main_queue(), block: dispatch_block_t) {
+    fileprivate func asyncAfter(_ seconds: Double, queue: DispatchQueue = DispatchQueue.main, block: @escaping ()->()) {
         let nanoSeconds = Int64(seconds * Double(NSEC_PER_SEC))
-        let time = dispatch_time(DISPATCH_TIME_NOW, nanoSeconds)
+        let time = DispatchTime.now() + Double(nanoSeconds) / Double(NSEC_PER_SEC)
         at(time, block: block, queue: queue)
     }
-    private func at(time: dispatch_time_t, block: dispatch_block_t, queue: dispatch_queue_t) {
+    fileprivate func at(_ time: DispatchTime, block: @escaping ()->(), queue: DispatchQueue) {
         // See Async.async() for comments
-        dispatch_after(time, queue, block)
+        queue.asyncAfter(deadline: time, execute: block)
     }
 }

--- a/Test/ThreadTests.swift
+++ b/Test/ThreadTests.swift
@@ -30,7 +30,7 @@ class ThreadTests: XCTestCase {
     func testEnqueueSingle() {
         let expectation = self.expectation(description: "First")
 
-        let thread = SwiftyThread()
+        let thread = threadForPlatform()
         thread.enqueue {
             expectation.fulfill()
         }
@@ -41,7 +41,7 @@ class ThreadTests: XCTestCase {
         let expectation1 = expectation(description: "First")
         let expectation2 = expectation(description: "Second")
 
-        let thread = SwiftyThread()
+        let thread = threadForPlatform()
         var visitedFirst = false
         thread.enqueue {
             expectation1.fulfill()
@@ -58,7 +58,7 @@ class ThreadTests: XCTestCase {
         let expectation1 = expectation(description: "First")
         let expectationWait = expectation(description: "Wait")
 
-        let thread = SwiftyThread()
+        let thread = threadForPlatform()
         thread.enqueue {
             thread.cancel()
             expectation1.fulfill()
@@ -79,7 +79,7 @@ class ThreadTests: XCTestCase {
         let expectation1 = expectation(description: "First")
         let expectationWait = expectation(description: "Wait")
 
-        let thread = SwiftyThread()
+        let thread = threadForPlatform()
         thread.enqueue {
             expectation1.fulfill()
             Thread.sleep(forTimeInterval: 0.1)
@@ -106,7 +106,7 @@ class ThreadTests: XCTestCase {
         let expectation2 = expectation(description: "Second")
         let expectationWait = expectation(description: "Wait")
 
-        let thread = SwiftyThread()
+        let thread = threadForPlatform()
         var paused: Bool = false
         var resumed: Bool = false
         thread.enqueue {
@@ -141,6 +141,14 @@ class ThreadTests: XCTestCase {
 
 extension ThreadTests {
 
+    #if os(iOS)
+    fileprivate func threadForPlatform() -> ThreadiOS.Thread { return ThreadiOS.Thread() }
+    #elseif os(tvOS)
+    fileprivate func threadForPlatform() -> ThreadtvOS.Thread { return ThreadtvOS.Thread() }
+    #elseif os(OSX)
+    fileprivate func threadForPlatform() -> ThreadOSX.Thread { return ThreadOSX.Thread() }
+    #endif
+    
     fileprivate func asyncAfter(_ seconds: Double, queue: DispatchQueue = DispatchQueue.main, block: @escaping ()->()) {
         let nanoSeconds = Int64(seconds * Double(NSEC_PER_SEC))
         let time = DispatchTime.now() + Double(nanoSeconds) / Double(NSEC_PER_SEC)

--- a/Test/ThreadiOS/AppDelegate.swift
+++ b/Test/ThreadiOS/AppDelegate.swift
@@ -14,30 +14,30 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
 
-    func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         return true
     }
 
-    func applicationWillResignActive(application: UIApplication) {
+    func applicationWillResignActive(_ application: UIApplication) {
         // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
         // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.
     }
 
-    func applicationDidEnterBackground(application: UIApplication) {
+    func applicationDidEnterBackground(_ application: UIApplication) {
         // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
         // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
     }
 
-    func applicationWillEnterForeground(application: UIApplication) {
+    func applicationWillEnterForeground(_ application: UIApplication) {
         // Called as part of the transition from the background to the inactive state; here you can undo many of the changes made on entering the background.
     }
 
-    func applicationDidBecomeActive(application: UIApplication) {
+    func applicationDidBecomeActive(_ application: UIApplication) {
         // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
     }
 
-    func applicationWillTerminate(application: UIApplication) {
+    func applicationWillTerminate(_ application: UIApplication) {
         // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
     }
 

--- a/Test/ThreadtvOS/AppDelegate.swift
+++ b/Test/ThreadtvOS/AppDelegate.swift
@@ -14,30 +14,30 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
 
-    func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         return true
     }
 
-    func applicationWillResignActive(application: UIApplication) {
+    func applicationWillResignActive(_ application: UIApplication) {
         // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
         // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.
     }
 
-    func applicationDidEnterBackground(application: UIApplication) {
+    func applicationDidEnterBackground(_ application: UIApplication) {
         // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
         // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
     }
 
-    func applicationWillEnterForeground(application: UIApplication) {
+    func applicationWillEnterForeground(_ application: UIApplication) {
         // Called as part of the transition from the background to the inactive state; here you can undo many of the changes made on entering the background.
     }
 
-    func applicationDidBecomeActive(application: UIApplication) {
+    func applicationDidBecomeActive(_ application: UIApplication) {
         // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
     }
 
-    func applicationWillTerminate(application: UIApplication) {
+    func applicationWillTerminate(_ application: UIApplication) {
         // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
     }
 


### PR DESCRIPTION
I migrated the source code and unit tests. Only thing is I had to create a `type alias` because the unit tests were getting confused with `Foundation.Thread`, so I called the alias:
```
typealias SwiftyThread = Thread
```
Thank you for this very useful project. `GCD` is great, but not for thread-unsafe resources like `Realm` or `Couchbase`. This library saved me and so pleasant to use! I hope this project gets more stars 👍 